### PR TITLE
Refactor PerplexitySearchConnector to return detailed search results

### DIFF
--- a/dist/models/PerplexitySearchConnector.js
+++ b/dist/models/PerplexitySearchConnector.js
@@ -31,6 +31,10 @@ export class PerplexitySearchConnector {
                 i++;
             }
         }
-        return result;
+        return {
+            output: result,
+            inputTokens: response.usage?.prompt_tokens ?? 0,
+            outputTokens: response.usage?.completion_tokens ?? 0,
+        };
     }
 }

--- a/dist/types/models/PerplexitySearchConnector.d.ts
+++ b/dist/types/models/PerplexitySearchConnector.d.ts
@@ -1,6 +1,6 @@
-import { IAISearchConnector } from '@crewdle/web-sdk-types';
+import { IAISearchConnector, IAISearchConnectorResult } from '@crewdle/web-sdk-types';
 export declare class PerplexitySearchConnector implements IAISearchConnector {
     private client;
     constructor(apiKey: string);
-    search(query: string, modelId: string): Promise<string>;
+    search(query: string, modelId: string): Promise<IAISearchConnectorResult>;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crewdle/mist-connector-perplexity",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",
@@ -23,7 +23,7 @@
     "dist/"
   ],
   "devDependencies": {
-    "@crewdle/web-sdk-types": "^1.0.37",
+    "@crewdle/web-sdk-types": "^1.0.43",
     "@types/node": "^22.0.0",
     "typescript": "^5.5.4"
   },

--- a/src/models/PerplexitySearchConnector.ts
+++ b/src/models/PerplexitySearchConnector.ts
@@ -1,6 +1,6 @@
 import OpenAI from 'openai';
 
-import { IAISearchConnector } from '@crewdle/web-sdk-types';
+import { IAISearchConnector, IAISearchConnectorResult } from '@crewdle/web-sdk-types';
 
 export class PerplexitySearchConnector implements IAISearchConnector {
   private client: OpenAI;
@@ -12,7 +12,7 @@ export class PerplexitySearchConnector implements IAISearchConnector {
     });
   }
 
-  async search(query: string, modelId: string): Promise<string> {
+  async search(query: string, modelId: string): Promise<IAISearchConnectorResult> {
     const response = await this.client.chat.completions.create({
       model: modelId,
       messages: [
@@ -39,6 +39,10 @@ export class PerplexitySearchConnector implements IAISearchConnector {
       }
     }
 
-    return result;
+    return {
+      output: result,
+      inputTokens: response.usage?.prompt_tokens ?? 0,
+      outputTokens: response.usage?.completion_tokens ?? 0,
+    };
   }
 }


### PR DESCRIPTION
- Update search method to return an object containing output, inputTokens, and outputTokens.
- Change return type of search method to IAISearchConnectorResult for better type safety.